### PR TITLE
ci: check linting and validate that `convert.py` was run

### DIFF
--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -41,4 +41,4 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Run validation
         run: python convert.py
-    
+

--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -41,4 +41,3 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Run validation
         run: python convert.py
-

--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -1,0 +1,44 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.py'
+      - '**.json'
+      - 'tox.ini'
+      - '.github/workflows/maintests.yml'
+      - '.github/workflows/prtests.yml'
+      - '.pre-commit-config.yaml'
+      - 'scripts/requirements.txt'
+      - 'scripts/requirements.dev.txt'
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0
+
+  verify-models-db:
+    env:
+      TESTS_ONGOING: "1"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Run validation
+        run: python convert.py
+    

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -46,4 +46,4 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Run validation
         run: python convert.py
-    
+

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -46,4 +46,3 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Run validation
         run: python convert.py
-

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -1,0 +1,49 @@
+name: Unstable Tests
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+    paths:
+      - '**.py'
+      - '**.json'
+      - 'tox.ini'
+      - '.github/workflows/maintests.yml'
+      - '.github/workflows/prtests.yml'
+      - '.pre-commit-config.yaml'
+      - 'scripts/requirements.txt'
+      - 'scripts/requirements.dev.txt'
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.10"]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0
+
+  verify-models-db:
+    env:
+      TESTS_ONGOING: "1"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.10"]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Run validation
+        run: python convert.py
+    

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,167 @@
+.tox
+
+.ruff_cache
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+*.webp
+*.png
+*.jpg

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+db_test.json
 .tox
 
 .ruff_cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,6 @@ repos:
     -   id: trailing-whitespace
 
 - repo: https://github.com/alan-turing-institute/CleverCSV-pre-commit
-  rev: v0.8.2     
+  rev: v0.8.2
   hooks:
   - id: clevercsv-standardize

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    -   id: check-yaml
+    -   id: check-json
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+
+- repo: https://github.com/alan-turing-institute/CleverCSV-pre-commit
+  rev: v0.8.2     
+  hooks:
+  - id: clevercsv-standardize

--- a/convert.py
+++ b/convert.py
@@ -50,7 +50,7 @@ if TESTS_ONGOING and os.path.exists(output_file):
     # Instead, we'll write to a new file and make sure the two files are the same
     # by comparing them as strings
     with open("db_test.json", "w") as f:
-        json.dump(data, f, indent=4)        
+        json.dump(data, f, indent=4)
         f.write("\n")
 
     with open(output_file, "r") as f:
@@ -66,4 +66,3 @@ else:
     with open(output_file, "w") as f:
         json.dump(data, f, indent=4)
         f.write("\n")
-

--- a/convert.py
+++ b/convert.py
@@ -59,7 +59,9 @@ if TESTS_ONGOING and os.path.exists(output_file):
     with open("db_test.json", "r") as f:
         new_data = f.read()
 
-    assert old_data == new_data, "db.json and db_test.json are different. Did you forget to run `convert.py`?"
+    if old_data != new_data:
+        print("db.json and db_test.json are different. Did you forget to run `convert.py`?")
+        exit(1)
 else:
     with open(output_file, "w") as f:
         json.dump(data, f, indent=4)

--- a/db.json
+++ b/db.json
@@ -8044,5 +8044,32 @@
         "version": "1",
         "style": "generalist",
         "nsfw": false
+    },
+    "TheDrummer/Moistral-11B-v3": {
+        "name": "TheDrummer/Moistral-11B-v3",
+        "baseline": "opt",
+        "parameters": 11000000000,
+        "description": "Add me",
+        "version": "1",
+        "style": "generalist",
+        "nsfw": false
+    },
+    "aphrodite/TheDrummer/Moistral-11B-v3": {
+        "name": "aphrodite/TheDrummer/Moistral-11B-v3",
+        "baseline": "opt",
+        "parameters": 11000000000,
+        "description": "Add me",
+        "version": "1",
+        "style": "generalist",
+        "nsfw": false
+    },
+    "koboldcpp/Moistral-11B-v3": {
+        "name": "koboldcpp/Moistral-11B-v3",
+        "baseline": "opt",
+        "parameters": 11000000000,
+        "description": "Add me",
+        "version": "1",
+        "style": "generalist",
+        "nsfw": false
     }
 }


### PR DESCRIPTION
This is to facilitate new contributors to this repo as @henk717 will be stepping away from regularly maintaining the models list. @candre23 will be the primary beneficiary of this change but there is a potential that others may end up stepping in. 

To simplify this, the changes in this PR will cause github workflows to run which check:

- That whitespace formatting is correct (file line endings, no extra whitespace, etc)
- That *.csv and *.json files are well-formed
- That running `convert.py` would result in the exact `db.json` file that is currently in the repo
  - For PRs, this checks that the incoming `models.csv` matches the incoming `db.json`.